### PR TITLE
Reduce replicas to 2

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -3,7 +3,7 @@
     "namespace": "srtl-production",
     "environment": "production",
     "enable_monitoring" : true,
-    "replicas": 8,
+    "replicas": 2,
     "external_url": "https://calculate-teacher-pay.education.gov.uk/healthcheck",
     "statuscake_contact_groups": [195955]
 }


### PR DESCRIPTION
The number of replicas was initially set to 8 for launch to attend high user traffic. Now the traffic is minimal, we can reduce the cost by scaling down to 2.

It should be increased again if the site is relaunched.