### PR TITLE
Enable azure rbac deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           terraform_version: 1.5.1
           terraform_wrapper: false
 
-      - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -29,7 +29,7 @@ jobs:
           terraform_version: 1.5.1
           terraform_wrapper: false
 
-      - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ SERVICE_NAME=calculate-teacher-pay
 SERVICE_SHORT=ctp
 
 .PHONY: development
-development:
+development: test-cluster
 	$(eval include global_config/development.sh)
 
-production:
+production: production-cluster
 	$(eval include global_config/production.sh)
 
 domains:
@@ -92,3 +92,15 @@ domains-plan: domains-init
 
 domains-apply: domains-init
 	terraform -chdir=terraform/domains/environment_domains apply -var-file config/${CONFIG}.tfvars.json ${AUTO_APPROVE}
+
+test-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189t01-tsc-ts-rg)
+	$(eval CLUSTER_NAME=s189t01-tsc-test-aks)
+
+production-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189p01-tsc-pd-rg)
+	$(eval CLUSTER_NAME=s189p01-tsc-production-aks)
+
+get-cluster-credentials: set-azure-account
+	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}
+	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -34,6 +34,15 @@ provider "kubernetes" {
   client_certificate     = module.cluster_data.kubernetes_client_certificate
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
 }
 
 provider "statuscake" {


### PR DESCRIPTION
## Description

Enable azure rbac on deployment (for when it is enabled in the cluster)

## Trello Card Link

https://trello.com/c/3m8PNLG6/937-enable-azure-rbac-deployment-on-all-services

Not to be deployed until terraform modules has been updated on Monday Jan 29th.

### Changes proposed in this pull request

Update Makefile, terraform and workflows to use rbac if configured for the cluster

### Guidance to review

make env get-cluster-credentials
make env terraform-plan
