### PR TITLE
CI-CD for domains

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,3 +71,63 @@ jobs:
         env:
           TF_VAR_azure_sp_credentials_json: ${{ secrets.AZURE_CREDENTIALS }}
           DOCKER_IMAGE_TAG: ${{ needs.build.outputs.docker-image-tag }}
+
+  deploy_domains_infra:
+    name: Deploy Domains Infrastructure
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_production
+    needs: [deploy]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+
+      - name: Deploy Domains Infrastructure
+        id: deploy_domains_infra
+        uses: DFE-Digital/github-actions/deploy-domains-infra@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+
+  deploy_domains_env:
+    name: Deploy Domains to ${{ matrix.domain_environment }} environment
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency: deploy_${{ matrix.domain_environment }}
+    needs: [deploy_domains_infra]
+    strategy:
+      max-parallel: 1
+      matrix:
+        domain_environment: [development, production]
+    environment:
+      name: production
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+
+      - name: Deploy Domains Environment
+        id: deploy_domains_env
+        uses: DFE-Digital/github-actions/deploy-domains-env@master
+        with:
+          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
+          azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
+          azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
+          environment: ${{ matrix.domain_environment }}
+          healthcheck: healthcheck
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.116.0"
   hashes = [
     "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
+    "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",

--- a/terraform/domains/environment_domains/output.tf
+++ b/terraform/domains/environment_domains/output.tf
@@ -1,0 +1,10 @@
+output "external_urls" {
+  value = flatten([
+    for zone_name, zone_values in var.hosted_zone : [
+      for domain in zone_values["domains"] : (domain == "apex" ?
+        "https://${zone_name}" :
+        "https://${domain}.${zone_name}"
+      )
+    ]
+  ])
+}


### PR DESCRIPTION
# Context

adding workflows for domain deployment to build workflows 

## Changes proposed in this pull request

updated deploy.yml adding calls to the deploy domains github actions. 
output.tf is added to provide external_urls for testing

## Guidance to review

checkout branch and run the following 

```
make development domains-plan 
make production domains-plan
make domains-infra-plan
```

verify the external urls are correct. 

in browser check health check url 

`https://calculate-teacher-pay.education.gov.uk/healthcheck`

verify the code in the github action 
verify the list of domain_environments is correct 

## Link to Trello card

[Implement CI/CD for domains on all services](https://trello.com/c/qyXB3RQA/1972-implement-ci-cd-for-domains-on-all-services)