### PR TITLE
run k6 as non root user

### DIFF
--- a/load_testing/Dockerfile
+++ b/load_testing/Dockerfile
@@ -1,9 +1,10 @@
 FROM grafana/xk6:0.9.2 as builder
 WORKDIR /build
-RUN xk6 build --with github.com/szkiba/xk6-dashboard@v0.4.3
+RUN xk6 build --with github.com/szkiba/xk6-dashboard@v0.4.4
 RUN chmod +x k6
 
 FROM alpine:3.14
+RUN adduser -D -u 12345 -g 12345 k6
 
 ENV BASE_URL http://0.0.0.0:3000
 ENV HTTP_USERNAME test
@@ -15,5 +16,6 @@ COPY loadtest.js .
 COPY --from=builder /build/k6 /usr/local/bin/k6
 
 EXPOSE 5665
+USER k6
 
 CMD k6 run --linger --out dashboard loadtest.js

--- a/load_testing/manifests/app.yml
+++ b/load_testing/manifests/app.yml
@@ -18,7 +18,11 @@ spec:
       restartPolicy: Never
       containers:
         - name: k6-client
-          image: ghcr.io/dfe-digital/k6-client:3
+          image: ghcr.io/dfe-digital/k6-client:k6nonroot
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 12345
           env:
             - name: BASE_URL
               value: "https://development.calculate-teacher-pay.education.gov.uk"


### PR DESCRIPTION
# Context

Security recommendations for the container from ITHC

## Changes proposed in this pull request

Updates the k6 dockerfile to run as a non-root user

## Guidance to review

Manually deployed to the development environment, and it worked as expected.

kubectl -n srtl-development exec -ti --tty pod/k6-client-nnnnnn -- /bin/sh
```
/tests $ ps -ef
PID   USER     TIME  COMMAND
    1 k6        0:19 k6 run --linger --out dashboard loadtest.js
   16 k6        0:00 /bin/sh
   22 k6        0:00 ps -ef
/tests $ id
uid=12345(k6) gid=12345(k6) groups=12345(k6)
```

kubectl -n srtl-development logs job/k6-client

```
  execution: local
     script: loadtest.js
     output: dashboard (:5665) http://127.0.0.1:5665

  scenarios: (100.00%) 1 scenario, 2 max VUs, 5m30s max duration (incl. graceful stop):
           * average_load: Up to 2 looping VUs for 5m0s over 1 stages (gracefulRampDown: 30s, gracefulStop: 30s)


running (0m01.0s), 1/2 VUs, 16 complete and 0 interrupted iterations
average_load   [   0% ] 1/2 VUs  0m01.0s/5m00.0s
etc
```

## Link to Trello card

https://trello.com/c/2ASYdoe5/2239-docker-container-fixes