### PR TITLE
feat(2433): ctp: aks container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN rm -rf node_modules log/* tmp/* /tmp && \
 # Build runtime image
 FROM ruby:3.4.1-alpine as production
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
 
 # The application runs from /app
 WORKDIR /app
@@ -72,8 +72,8 @@ RUN apk add --no-cache gcompat
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-RUN chown -hR appuser:appgroup /app
+RUN chown -hR appuser:appgroup /app/tmp
 
-USER appuser
+USER 10001
 
 CMD bundle exec rails server -b 0.0.0.0

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -37,4 +37,5 @@ module "web_application" {
   docker_image                 = "${local.docker_repository}:${var.docker_image_tag}"
   github_username              = module.infrastructure_secrets.map.GITHUB-USERNAME
   github_personal_access_token = module.infrastructure_secrets.map.GITHUB-PERSONAL-ACCESS-TOKEN
+  run_as_non_root              = var.run_as_non_root
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -12,6 +12,12 @@ variable "external_url" { default = null }
 variable "statuscake_contact_groups" { default = [] }
 variable "enable_monitoring" { default = false }
 
+variable "run_as_non_root" {
+  type        = bool
+  default     = true
+  description = "Whether to enforce that containers must run as non-root user"
+}
+
 locals {
   docker_repository = "ghcr.io/dfe-digital/teacher-pay-calculator"
 


### PR DESCRIPTION
### Context

[Ticket: https://trello.com/c/ktsJEPED/2326-use-build-docker-image-github-action?filter=member:paulsenior26](https://trello.com/c/RmmbJFpw/2433-security-aks-containers-run-as-non-root-user-ctpsrtl)

[Why are we making this change?]
- comply with security (this is a recommendation off the ITHC and follows AKS best practice guidelines)

[What has been changed?]
- amend existing nonroot user (appuser) to run with numeric id
- force terraform to ensure container is run as nonroot user

[Evidence/Guidance for Review]
- tested in development environment
<img width="1460" height="116" alt="Screenshot from 2025-08-18 11-00-17" src="https://github.com/user-attachments/assets/099fa852-dbc8-4507-813b-e92e62201752" />
