### PR TITLE
Pin libcrypto3=3.3.7-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --update --no-cache tzdata && \
 # build-base: dependencies for bundle
 # gcompat: dependencies for nokogiri
 # yarn: node package manager
-RUN apk add --no-cache build-base gcompat yarn libcrypto3=3.3.6-r0
+RUN apk add --no-cache build-base gcompat yarn
 
 # Install gems defined in Gemfile
 COPY .ruby-version Gemfile Gemfile.lock ./
@@ -66,7 +66,7 @@ RUN apk add --update --no-cache tzdata && \
     echo "Europe/London" > /etc/timezone
 
 # gcompat: required by nokogiri
-RUN apk add --no-cache gcompat libcrypto3=3.3.6-r0
+RUN apk add --no-cache gcompat
 
 # Copy files generated in the builder image
 COPY --from=builder /app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --update --no-cache tzdata && \
 # build-base: dependencies for bundle
 # gcompat: dependencies for nokogiri
 # yarn: node package manager
-RUN apk add --no-cache build-base gcompat yarn
+RUN apk add --no-cache build-base gcompat yarn libcrypto3=3.3.7-r0
 
 # Install gems defined in Gemfile
 COPY .ruby-version Gemfile Gemfile.lock ./
@@ -66,7 +66,7 @@ RUN apk add --update --no-cache tzdata && \
     echo "Europe/London" > /etc/timezone
 
 # gcompat: required by nokogiri
-RUN apk add --no-cache gcompat
+RUN apk add --no-cache gcompat libcrypto3=3.3.7-r0
 
 # Copy files generated in the builder image
 COPY --from=builder /app /app


### PR DESCRIPTION
### Changes proposed in this pull request

Update pinned version of libcrypto3=3.3.7-r0 from [PR](https://github.com/DFE-Digital/teacher-pay-calculator/pull/311)
Existing pin 3.3.6-r0 breaks build - [build-no-cache](https://github.com/DFE-Digital/teacher-pay-calculator/actions/runs/24956956042/job/73076793405)
Standard version when unpinned has security vulnerabilities, [see here](https://github.com/DFE-Digital/teacher-pay-calculator/actions/runs/25001918057/job/73214074576#step:5:1621)

### Guidance to review

See [build-no-cache](https://github.com/DFE-Digital/teacher-pay-calculator/actions/runs/25002348983)