### PR TITLE
2683 - Removed redundant parameters

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -39,5 +39,3 @@ jobs:
           validation-plan: ${{ matrix.validation_plan }}
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
-          docker-repo: true
-          service-name: teacher-pay-calculator


### PR DESCRIPTION
## Context

Update the GitHub central action so that docker image strings can be defined differently in different services.
This version covers all possible combinations.

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

## Changes proposed in this pull request

The **Set environment variables** step has been refactored to allow for the construction of all sections of the docker image string or any combination.

## Guidance to review

You can run the "Validate Infra" workflow if it already exists for the service. You can point it at the branch but that will always produce a false positive as the docker image will be different for main/master and the branch. This will produce a workflow Teams message in SD Infra Alerts.

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/b2f7861d-33c5-4382-ab95-1b73e580fc86" />

There are 3 jobs in the workflow, AKS infrastructure, Domains infrastructure and Domains environment. The workflow card will show which job to look at in the bottom left corner (Infrastructure in the image above). You can click the Workflow Run button to go to the correct run.
The jobs must show a green tick not a red cross.
You can alter any value in the terraform production.tfvars.json in your branch to check that the terraform plan picks up those changes, remembering that the docker image is a false positive.

If the workflow does not exist you will have to test locally using the service specific `make production terraform-plan` command for the service. 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
